### PR TITLE
Enable `Children = [AnyNode]` for Button and Label components

### DIFF
--- a/Example/Tokamak/Components/CollectionExample.swift
+++ b/Example/Tokamak/Components/CollectionExample.swift
@@ -38,12 +38,15 @@ private struct Cells: SimpleCellProvider {
     item: ElementaryParticles,
     path: CellPath
   ) -> AnyNode {
-    return Label.node(.init(Style(
-      [CenterY.equal(to: .parent),
-       Height.equal(to: 44),
-       Leading.equal(to: .parent),
-       Trailing.equal(to: .parent)]
-    )), "\(item.description)")
+    return Label.node(.init(
+      Style(
+        [CenterY.equal(to: .parent),
+         Height.equal(to: 44),
+         Leading.equal(to: .parent),
+         Trailing.equal(to: .parent)]
+      ),
+      text: "\(item.description)"
+    ))
   }
 
   typealias Props = Null

--- a/Example/Tokamak/Components/Constraints.swift
+++ b/Example/Tokamak/Components/Constraints.swift
@@ -30,8 +30,9 @@ struct Constraints: LeafComponent {
         Label.node(.init(
           Style(Left.equal(to: .parent, constant: Double(left.value) * 200)),
           alignment: .center,
+          text: "\(left.value)",
           textColor: .white
-        ), "\(left.value)")
+        ))
       ),
     ])
   }

--- a/Example/Tokamak/Components/Controls.swift
+++ b/Example/Tokamak/Components/Controls.swift
@@ -31,10 +31,10 @@ struct Controls: LeafComponent {
             )
           ),
 
-          Label.node(
-            .init(alignment: .center),
-            "isEnabled \(isEnabled.value)"
-          ),
+          Label.node(.init(
+            alignment: .center,
+            text: "isEnabled \(isEnabled.value)"
+          )),
         ]
       ),
 
@@ -45,7 +45,7 @@ struct Controls: LeafComponent {
         valueHandler: Handler(sliding.set)
       )),
 
-      Label.node(.init(alignment: .center), "\(sliding.value)"),
+      Label.node(.init(alignment: .center, text: "\(sliding.value)")),
 
       StackView.node(
         .init(
@@ -61,7 +61,7 @@ struct Controls: LeafComponent {
             )
           ),
 
-          Label.node(.init(alignment: .center), "\(switchState.value)"),
+          Label.node(.init(alignment: .center, text: "\(switchState.value)")),
         ]
       ),
 
@@ -84,7 +84,7 @@ struct Controls: LeafComponent {
             )
           ),
 
-          Label.node(.init(alignment: .center), "\(stepperState.value)"),
+          Label.node(.init(alignment: .center, text: "\(stepperState.value)")),
         ]
       ),
     ]

--- a/Example/Tokamak/Components/Counter.swift
+++ b/Example/Tokamak/Components/Counter.swift
@@ -22,12 +22,12 @@ struct Counter: LeafComponent {
       axis: .vertical,
       distribution: .fillEqually
     ), [
-      Button.node(
-        .init(onPress: Handler { count.set { $0 + 1 } }),
-        "Increment"
-      ),
+      Button.node(.init(
+        onPress: Handler { count.set { $0 + 1 } },
+        text: "Increment"
+      )),
 
-      Label.node(.init(alignment: .center), "\(count.value)"),
+      Label.node(.init(alignment: .center, text: "\(count.value)")),
     ])
   }
 }

--- a/Example/Tokamak/Components/DatePickers.swift
+++ b/Example/Tokamak/Components/DatePickers.swift
@@ -18,25 +18,24 @@ struct DatePickers: LeafComponent {
     dateFormatter.dateStyle = .medium
     dateFormatter.timeStyle = .medium
     let formattedDate = dateFormatter.string(from: date.value)
-    let labelProps = Label.Props(
-      alignment: .center,
-      lineBreakMode: .wordWrap,
-      numberOfLines: 0
-    )
 
     return StackView.node(.init(
       Edges.equal(to: .safeArea),
       axis: .vertical,
       distribution: .fillEqually
     ), [
-      Label.node(
-        labelProps,
-        "\(formattedDate)"
-      ),
-      Label.node(
-        labelProps,
-        "This picker doesn't animate state changes in the next picker:"
-      ),
+      Label.node(.init(
+        alignment: .center,
+        lineBreakMode: .wordWrap,
+        numberOfLines: 0,
+        text: "\(formattedDate)"
+      )),
+      Label.node(.init(
+        alignment: .center,
+        lineBreakMode: .wordWrap,
+        numberOfLines: 0,
+        text: "This picker doesn't animate state changes in the next picker:"
+      )),
       DatePicker.node(
         .init(
           Style(Width.equal(to: .parent)),
@@ -44,10 +43,12 @@ struct DatePickers: LeafComponent {
           valueHandler: Handler(date.set)
         )
       ),
-      Label.node(
-        labelProps,
-        "This picker animates state changes in the previous picker:"
-      ),
+      Label.node(.init(
+        alignment: .center,
+        lineBreakMode: .wordWrap,
+        numberOfLines: 0,
+        text: "This picker animates state changes in the previous picker:"
+      )),
       DatePicker.node(
         .init(
           Style(Width.equal(to: .parent)),

--- a/Example/Tokamak/Components/LayerProps.swift
+++ b/Example/Tokamak/Components/LayerProps.swift
@@ -42,8 +42,9 @@ struct LayerProps: LeafComponent {
                Left.equal(to: .parent, constant: Double(state.value) * 200)]
             ),
             alignment: .center,
+            text: "\(state.value)",
             textColor: .white
-          ), "\(state.value)")
+          ))
         ),
       ])
   }

--- a/Example/Tokamak/Components/List.swift
+++ b/Example/Tokamak/Components/List.swift
@@ -14,11 +14,14 @@ private struct Cells: SimpleCellProvider {
     item: AppRoute,
     path: CellPath
   ) -> AnyNode {
-    return Label.node(.init(Style(
-      [CenterY.equal(to: .parent),
-       Height.equal(to: 44),
-       Leading.equal(to: .safeArea, constant: 20)]
-    )), "\(item.description)")
+    return Label.node(.init(
+      Style(
+        [CenterY.equal(to: .parent),
+         Height.equal(to: 44),
+         Leading.equal(to: .safeArea, constant: 20)]
+      ),
+      text: "\(item.description)"
+    ))
   }
 
   typealias Props = Null

--- a/Example/Tokamak/Components/ModalRouter.swift
+++ b/Example/Tokamak/Components/ModalRouter.swift
@@ -28,8 +28,9 @@ struct ModalRouter: NavigationRouter {
     let close =
       Button.node(.init(
         Style(Rectangle(.zero, Size(width: 200, height: 200))),
-        onPress: props.onPress
-      ), "Close Modal")
+        onPress: props.onPress,
+        text: "Close Modal"
+      ))
     switch route {
     case .first:
       return
@@ -41,9 +42,9 @@ struct ModalRouter: NavigationRouter {
               Button.node(.init(
                 Style(Rectangle(Point(x: 0, y: 400),
                                 Size(width: 200, height: 200))),
-                onPress: Handler { push(.second) }
-
-              ), "Go to Second"),
+                onPress: Handler { push(.second) },
+                text: "Go to Second"
+              )),
             ]
           )
         )
@@ -57,8 +58,9 @@ struct ModalRouter: NavigationRouter {
               Label.node(.init(
                 Style(Rectangle(Point(x: 0, y: 200),
                                 Size(width: 200, height: 200))),
-                alignment: .center
-              ), "This is second"),
+                alignment: .center,
+                text: "This is second"
+              )),
             ]
           )
         )

--- a/Example/Tokamak/Components/Modals.swift
+++ b/Example/Tokamak/Components/Modals.swift
@@ -36,11 +36,14 @@ struct SimpleModal: PureLeafComponent {
 
   static func render(props: Props) -> AnyNode {
     return props.isPresented.value ? ModalPresenter.node(
-      Animation.node(Null(),
-                     Button.node(.init(
-                       Style(Center.equal(to: .parent)),
-                       onPress: Handler { props.isPresented.set(false) }
-      ), "Close Modal"))
+      Animation.node(
+        Null(),
+        Button.node(.init(
+          Style(Center.equal(to: .parent)),
+          onPress: Handler { props.isPresented.set(false) },
+          text: "Close Modal"
+        ))
+      )
     ) : Null.node()
   }
 }
@@ -61,20 +64,20 @@ struct Modals: LeafComponent {
         distribution: .fillEqually
       ),
       [
-        Button.node(
-          .init(onPress: Handler { isAnimationModalPresented.set(true) }),
-          "Present Simple Modal"
-        ),
+        Button.node(.init(
+          onPress: Handler { isAnimationModalPresented.set(true) },
+          text: "Present Simple Modal"
+        )),
 
-        Button.node(
-          .init(onPress: Handler { isStackModalPresented.set(true) }),
-          "Present Navigation Modal"
-        ),
+        Button.node(.init(
+          onPress: Handler { isStackModalPresented.set(true) },
+          text: "Present Navigation Modal"
+        )),
 
-        Button.node(
-          .init(onPress: Handler { isTableModalPresented.set(true) }),
-          "Present Table Modal"
-        ),
+        Button.node(.init(
+          onPress: Handler { isTableModalPresented.set(true) },
+          text: "Present Table Modal"
+        )),
 
         NavigationModal.node(.init(isPresented: isStackModalPresented)),
 

--- a/Example/Tokamak/Components/Scroll.swift
+++ b/Example/Tokamak/Components/Scroll.swift
@@ -22,7 +22,7 @@ struct ScrollViewExample: LeafComponent {
             axis: .vertical,
             distribution: .fill
           ),
-          (1..<100).map { Label.node("Text \($0)") }
+          (1..<100).map { Label.node(.init(text: "Text \($0)")) }
         )
       )
     )

--- a/Example/Tokamak/Components/SnakeGame/Gamepad.swift
+++ b/Example/Tokamak/Components/SnakeGame/Gamepad.swift
@@ -33,9 +33,9 @@ struct Gamepad: PureComponent {
           isEnabled: isVerticalMoveEnabled,
           onPress: Handler {
             game.set { $0.currentDirection = .up }
-          }
-        ),
-        "⬆️"
+          },
+          text: "⬆️"
+        )
       ),
       StackView.node(.init(
         [Width.equal(to: .parent)],
@@ -47,9 +47,9 @@ struct Gamepad: PureComponent {
             isEnabled: isHorizontalMoveEnabled,
             onPress: Handler {
               game.set { $0.currentDirection = .left }
-            }
-          ),
-          "⬅️"
+            },
+            text: "⬅️"
+          )
         ),
 
         Button.node(
@@ -57,9 +57,9 @@ struct Gamepad: PureComponent {
             isEnabled: isHorizontalMoveEnabled,
             onPress: Handler {
               game.set { $0.currentDirection = .right }
-            }
-          ),
-          "➡️"
+            },
+            text: "➡️"
+          )
         ),
       ]),
       Button.node(
@@ -67,8 +67,7 @@ struct Gamepad: PureComponent {
           Style(Width.equal(to: .parent, multiplier: 0.5)),
           isEnabled: isVerticalMoveEnabled,
           onPress: Handler { game.set { $0.currentDirection = .down } }
-        ),
-        "⬇️"
+        )
       ),
     ] + children)
   }

--- a/Example/Tokamak/Components/SnakeGame/Menu.swift
+++ b/Example/Tokamak/Components/SnakeGame/Menu.swift
@@ -34,10 +34,10 @@ struct GameMenu: PureComponent {
           distribution: .fillEqually,
           spacing: 10.0
         ),
-        Button.node(
-          .init(onPress: Handler { game.set { $0 = restartedGameState } }),
-          "Game over! Restart the game"
-        )
+        Button.node(.init(
+          onPress: Handler { game.set { $0 = restartedGameState } },
+          text: "Game over! Restart the game"
+        ))
       )
     case .initial:
       return StackView.node(
@@ -47,10 +47,10 @@ struct GameMenu: PureComponent {
           distribution: .fillEqually,
           spacing: 10.0
         ),
-        Button.node(
-          .init(onPress: Handler { game.set { $0.state = .isPlaying } }),
-          "Start the game"
-        )
+        Button.node(.init(
+          onPress: Handler { game.set { $0.state = .isPlaying } },
+          text: "Start the game"
+        ))
       )
     }
   }

--- a/Example/Tokamak/Components/SnakeGame/Snake.swift
+++ b/Example/Tokamak/Components/SnakeGame/Snake.swift
@@ -63,10 +63,10 @@ struct Snake: LeafComponent {
                   valueHandler: Handler(speed.set)
                 )
               ),
-              Label.node(
-                .init(alignment: .center),
-                "\(speed.value)X"
-              ),
+              Label.node(.init(
+                alignment: .center,
+                text: "\(speed.value)X"
+              )),
             ]
           ),
         ]

--- a/Example/Tokamak/Components/SnakeGame/StartGame.swift
+++ b/Example/Tokamak/Components/SnakeGame/StartGame.swift
@@ -29,9 +29,9 @@ struct StartGame: PureLeafComponent {
           isEnabled: isVerticalMoveEnabled,
           onPress: Handler {
             game.set { $0.currentDirection = .up }
-          }
-        ),
-        "⬆️"
+          },
+          text: "⬆️"
+        )
       ),
       StackView.node(.init(
         axis: .horizontal,
@@ -42,9 +42,9 @@ struct StartGame: PureLeafComponent {
             isEnabled: isHorizontalMoveEnabled,
             onPress: Handler {
               game.set { $0.currentDirection = .left }
-            }
-          ),
-          "⬅️"
+            },
+            text: "⬅️"
+          )
         ),
 
         Button.node(
@@ -52,17 +52,17 @@ struct StartGame: PureLeafComponent {
             isEnabled: isHorizontalMoveEnabled,
             onPress: Handler {
               game.set { $0.currentDirection = .right }
-            }
-          ),
-          "➡️"
+            },
+            text: "➡️"
+          )
         ),
       ]),
       Button.node(
         .init(
           isEnabled: isVerticalMoveEnabled,
-          onPress: Handler { game.set { $0.currentDirection = .down } }
-        ),
-        "⬇️"
+          onPress: Handler { game.set { $0.currentDirection = .down } },
+          text: "⬇️"
+        )
       ),
     ])
   }

--- a/Example/Tokamak/Components/TableModal.swift
+++ b/Example/Tokamak/Components/TableModal.swift
@@ -13,11 +13,14 @@ struct ListProvider: SimpleCellProvider {
   typealias Model = [[Int]]
 
   static func cell(props _: Null, item: Int, path _: CellPath) -> AnyNode {
-    return Label.node(.init(Style(
-      [CenterY.equal(to: .parent),
-       Height.equal(to: 44),
-       Leading.equal(to: .parent, constant: 20)]
-    )), "\(item)")
+    return Label.node(.init(
+      Style(
+        [CenterY.equal(to: .parent),
+         Height.equal(to: 44),
+         Leading.equal(to: .parent, constant: 20)]
+      ),
+      text: "\(item)"
+    ))
   }
 }
 
@@ -50,10 +53,10 @@ struct TableRouter: NavigationRouter {
           Edges.equal(to: .parent),
           backgroundColor: .white
         )),
-        Label.node(
-          .init(Style(Center.equal(to: .parent))),
-          "\(v)"
-        )
+        Label.node(.init(
+          Style(Center.equal(to: .parent)),
+          text: "\(v)"
+        ))
       )
     }
   }

--- a/Example/Tokamak/Components/Timer.swift
+++ b/Example/Tokamak/Components/Timer.swift
@@ -36,10 +36,10 @@ struct TimerCounter: LeafComponent {
         axis: .vertical,
         distribution: .fillEqually
       ), [
-        Label.node(
-          .init(alignment: .center),
-          "Adjust timer interval in seconds: \(interval.value)"
-        ),
+        Label.node(.init(
+          alignment: .center,
+          text: "Adjust timer interval in seconds: \(interval.value)"
+        )),
         Stepper.node(
           .init(
             minimumValue: 1.0,
@@ -47,10 +47,10 @@ struct TimerCounter: LeafComponent {
             valueHandler: Handler(interval.set)
           )
         ),
-        Label.node(
-          .init(alignment: .center),
-          "\(count.value) second\(count.value == 1 ? "" : "s") passed"
-        ),
+        Label.node(.init(
+          alignment: .center,
+          text: "\(count.value) second\(count.value == 1 ? "" : "s") passed"
+        )),
       ]
     )
   }

--- a/Sources/Tokamak/Components/Host/Button.swift
+++ b/Sources/Tokamak/Components/Host/Button.swift
@@ -15,12 +15,14 @@ public struct Button: HostComponent {
     public let style: Style?
     public let titleColor: Color?
     public let isEnabled: Bool
+    public let text: String
 
     public init(
       _ style: Style? = nil,
       handlers: [Event: Handler<()>] = [:],
       isEnabled: Bool = true,
       onPress: Handler<()>? = nil,
+      text: String = "",
       titleColor: Color? = nil
     ) {
       var handlers = handlers
@@ -31,8 +33,15 @@ public struct Button: HostComponent {
       self.style = style
       self.titleColor = titleColor
       self.isEnabled = isEnabled
+      self.text = text
     }
   }
 
-  public typealias Children = String
+  public typealias Children = [AnyNode]
+}
+
+extension Button.Props: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(text: value)
+  }
 }

--- a/Sources/Tokamak/Components/Host/Label.swift
+++ b/Sources/Tokamak/Components/Host/Label.swift
@@ -15,6 +15,7 @@ public struct Label: HostComponent {
     public let lineBreakMode: LineBreakMode
     public let numberOfLines: Int
     public let style: Style?
+    public let text: String
     public let textColor: Color?
 
     public init(
@@ -22,15 +23,23 @@ public struct Label: HostComponent {
       alignment: TextAlignment = .natural,
       lineBreakMode: LineBreakMode = .truncateTail,
       numberOfLines: Int = 1,
+      text: String = "",
       textColor: Color? = nil
     ) {
       self.alignment = alignment
       self.lineBreakMode = lineBreakMode
       self.numberOfLines = numberOfLines
+      self.text = text
       self.textColor = textColor
       self.style = style
     }
   }
 
-  public typealias Children = String
+  public typealias Children = [AnyNode]
+}
+
+extension Label.Props: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(text: value)
+  }
 }

--- a/Sources/TokamakUIKit/Components/Host/Button.swift
+++ b/Sources/TokamakUIKit/Components/Host/Button.swift
@@ -23,13 +23,13 @@ extension Button: UIControlComponent {
 
   static func update(control box: ControlBox<TokamakButton>,
                      _ props: Button.Props,
-                     _ children: String) {
+                     _ children: [AnyNode]) {
     let control = box.view
 
     if let titleColor = props.titleColor {
       control.setTitleColor(UIColor(titleColor), for: .normal)
     }
 
-    control.setTitle(children, for: .normal)
+    control.setTitle(props.text, for: .normal)
   }
 }

--- a/Sources/TokamakUIKit/Components/Host/Label.swift
+++ b/Sources/TokamakUIKit/Components/Host/Label.swift
@@ -36,12 +36,12 @@ extension Label: UIViewComponent {
 
   static func update(view box: ViewBox<TokamakLabel>,
                      _ props: Label.Props,
-                     _ children: String) {
+                     _ children: [AnyNode]) {
     let view = box.view
     view.textAlignment = NSTextAlignment(props.alignment)
     view.numberOfLines = props.numberOfLines
     view.lineBreakMode = NSLineBreakMode(props.lineBreakMode)
     view.textColor = props.textColor.flatMap { UIColor($0) }
-    view.text = children
+    view.text = props.text
   }
 }

--- a/Tests/TokamakTests/HooksTests.swift
+++ b/Tests/TokamakTests/HooksTests.swift
@@ -56,21 +56,25 @@ struct Test: LeafComponent {
 
     return StackView.node([
       Button.node(
-        .init(onPress: Handler { state1.set { $0 += 1 } }),
-        "Increment",
+        .init(
+          onPress: Handler { state1.set { $0 += 1 } },
+          text: "Increment"
+        ),
         ref: ref
       ),
-      Label.node("\(state1.value)"),
-      Button.node(.init(onPress: Handler { state2.set { $0 + 1 } }),
-                  "Increment"),
-      Label.node("\(state2.value)"),
+      Label.node(.init(text: "\(state1.value)")),
+      Button.node(.init(
+        onPress: Handler { state2.set { $0 + 1 } },
+        text: "Increment"
+      )),
+      Label.node(.init(text: "\(state2.value)")),
       Button.node(
         .init(
           onPress: Handler {
             state3.set { $0.points.append(Point(x: 42, y: 42)) }
-          }
-        ),
-        "Increment"
+          },
+          text: "Increment"
+        )
       ),
     ])
   }
@@ -108,8 +112,15 @@ final class HooksTests: XCTestCase {
     let e = expectation(description: "rerender")
 
     DispatchQueue.main.async {
-      XCTAssertEqual(stack.subviews[1].node.children, AnyEquatable("43"))
-      XCTAssertEqual(stack.subviews[3].node.children, AnyEquatable("44"))
+      guard let text1 = stack.subviews[1].props(Label.Props.self),
+        let text3 = stack.subviews[3].props(Label.Props.self) else {
+        XCTAssert(false, "wrong props types")
+        e.fulfill()
+        return
+      }
+
+      XCTAssertEqual(text1.text, "43")
+      XCTAssertEqual(text3.text, "44")
 
       e.fulfill()
     }

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -18,17 +18,20 @@ struct Counter: LeafComponent {
     let sliding = hooks.state(0.5 as Float)
 
     let children = count.value < 45 ? [
-      Button.node(.init(handlers: [
-        .touchUpInside: Handler { count.set { $0 + 1 } },
-      ]), "Increment"),
+      Button.node(.init(
+        handlers: [
+          .touchUpInside: Handler { count.set { $0 + 1 } },
+        ],
+        text: "Increment"
+      )),
 
-      Label.node(.init(), "\(count.value)"),
+      Label.node(.init(text: "\(count.value)")),
 
       Slider.node(Slider.Props(
         value: sliding.value, valueHandler: Handler(sliding.set)
       )),
 
-      Label.node(.init(), "\(sliding.value)"),
+      Label.node(.init(text: "\(sliding.value)")),
     ] : []
 
     return StackView.node(
@@ -55,7 +58,7 @@ final class ReconcilerTests: XCTestCase {
     XCTAssertEqual(stack.subviews.count, 4)
     XCTAssertTrue(stack.subviews[0].node.isSubtypeOf(Button.self))
     XCTAssertTrue(stack.subviews[1].node.isSubtypeOf(Label.self))
-    XCTAssertEqual(stack.subviews[1].node.children, AnyEquatable("42"))
+    XCTAssertEqual(stack.subviews[1].props(Label.Props.self)?.text, "42")
   }
 
   func testUpdate() {
@@ -86,7 +89,7 @@ final class ReconcilerTests: XCTestCase {
       XCTAssertTrue(newStack.subviews[0].node.isSubtypeOf(Button.self))
       XCTAssertTrue(newStack.subviews[1].node.isSubtypeOf(Label.self))
       XCTAssertTrue(originalLabel === newStack.subviews[1])
-      XCTAssertEqual(newStack.subviews[1].node.children, AnyEquatable("43"))
+      XCTAssertEqual(newStack.subviews[1].props(Label.Props.self)?.text, "43")
 
       e.fulfill()
     }
@@ -136,7 +139,7 @@ final class ReconcilerTests: XCTestCase {
         }
 
         XCTAssertEqual(sliderProps.value, 0.25)
-        XCTAssertEqual(newStack.subviews[1].node.children, AnyEquatable("43"))
+        XCTAssertEqual(newStack.subviews[1].props(Label.Props.self)?.text, "43")
 
         buttonHandler(())
 
@@ -153,7 +156,8 @@ final class ReconcilerTests: XCTestCase {
           XCTAssertTrue(originalLabel === newStack.subviews[1])
 
           XCTAssertEqual(sliderProps.value, 0.25)
-          XCTAssertEqual(newStack.subviews[1].node.children, AnyEquatable("44"))
+          XCTAssertEqual(newStack.subviews[1].props(Label.Props.self)?.text,
+                         "44")
           e.fulfill()
         }
       }


### PR DESCRIPTION
When in the future we add more components that would be useful as children of `Button` and `Label`, for example components that render to `CAShapeLayer`, we won't be able to add them as children. The reason is that this node "slot" is taken by text of `String` type. I think it's better to make this API-breaking change before the initial release, even though we don't have a component for `CAShapeLayer` yet.