### PR TITLE
Add factory functions creating `SizeConstraint`

### DIFF
--- a/Sources/Tokamak/Components/Props/Constraint/SizeConstraint.swift
+++ b/Sources/Tokamak/Components/Props/Constraint/SizeConstraint.swift
@@ -5,11 +5,20 @@
 //  Created by Max Desiatov on 02/02/2019.
 //
 
-public struct SizeConstraint: Equatable {
-  public enum Value: Equatable {
-    case constant(Size)
-    case multiplier(Constraint.Target, Double)
+public enum SizeConstraint: Equatable {
+  case constant(Size)
+  case multiplier(Constraint.Target, Double)
+}
+
+extension Size {
+  static func equal(to size: Size) -> SizeConstraint {
+    return .constant(size)
   }
 
-  public let value: Value
+  static func equal(
+    to target: Constraint.Target,
+    multiplier: Double = 1.0
+  ) -> SizeConstraint {
+    return .multiplier(target, multiplier)
+  }
 }

--- a/Sources/Tokamak/Hooks/Effect.swift
+++ b/Sources/Tokamak/Hooks/Effect.swift
@@ -8,7 +8,7 @@
 extension Hooks {
   /// Schedule an effect to be executed on every call to `render`.
   public func effect(closure: @escaping () -> ()) {
-    scheduleEffect(nil, { closure(); return nil })
+    scheduleEffect(nil) { closure(); return nil }
   }
 
   /** Schedule an effect to be executed on every call to `render`. The effect
@@ -34,7 +34,7 @@ extension Hooks {
    interval has changed.
    */
   public func effect<T: Equatable>(_ observed: T, closure: @escaping () -> ()) {
-    scheduleEffect(AnyEquatable(observed), { closure(); return nil })
+    scheduleEffect(AnyEquatable(observed)) { closure(); return nil }
   }
 
   /** Schedule an effect to be executed on calls to `render` when `observed`

--- a/Sources/TokamakAppKit/Boxes/ControlBox.swift
+++ b/Sources/TokamakAppKit/Boxes/ControlBox.swift
@@ -49,7 +49,7 @@ class ControlBox<T: NSControl & Default>: ViewBox<T> {
         return
       }
 
-      let events = eventMask.elements().compactMap({ Event($0) })
+      let events = eventMask.elements().compactMap { Event($0) }
 
       for e in events {
         self?.handlers[e]?.value(())

--- a/Sources/TokamakAppKit/Components/Props/Constraint/Constraint.swift
+++ b/Sources/TokamakAppKit/Components/Props/Constraint/Constraint.swift
@@ -61,7 +61,7 @@ extension NSView {
     case let .lastBaseline(location):
       return location.constraint(current: self, parent: superview, next: next)
     case let .size(size):
-      switch size.value {
+      switch size {
       case let .constant(constant):
         return constraint(
           Width.equal(to: .own, constant: constant.width), next: next

--- a/Sources/TokamakUIKit/Components/Props/Constraint/Constraint.swift
+++ b/Sources/TokamakUIKit/Components/Props/Constraint/Constraint.swift
@@ -61,7 +61,7 @@ extension UIView {
     case let .lastBaseline(location):
       return location.constraint(current: self, parent: superview, next: next)
     case let .size(size):
-      switch size.value {
+      switch size {
       case let .constant(constant):
         return constraint(
           Width.equal(to: .own, constant: constant.width), next: next


### PR DESCRIPTION
We had an existing `SizeConstraint` struct, which was correctly rendered to auto layout constraints, but there was no way for users to create `SizeConstraint` with the new auto layout syntax. This is fixed by adding extension functions on `Size` with the usual format. This now allows setting constraints for size with a constant value:

```swift
Size.equal(to: .init(width: 100, height: 200))
```

Or with a multiplier relative to other nodes:

```swift
Size.equal(to: .parent, multiplier: 0.5)
```