### PR TITLE
Fix CALayer-related props in TokamakAppKit

### DIFF
--- a/Sources/TokamakAppKit/Components/Protocols/NSViewComponent.swift
+++ b/Sources/TokamakAppKit/Components/Protocols/NSViewComponent.swift
@@ -8,12 +8,6 @@
 import AppKit
 import Tokamak
 
-public extension NSView {
-  var wantsUpdateLayer: Bool {
-    return true
-  }
-}
-
 protocol NSViewComponent: NSHostComponent, RefComponent {
   associatedtype Target: NSView & Default
 
@@ -31,8 +25,8 @@ protocol NSViewComponent: NSHostComponent, RefComponent {
   ) -> ViewBox<Target>
 }
 
-private func applyStyle<T: NSView, P: StyleProps>(_ target: ViewBox<T>,
-                                                  _ props: P) {
+private func applyStyle<T: NSView>(_ target: ViewBox<T>,
+                                   _ props: StyleProps) {
   guard let style = props.style else {
     return
   }

--- a/Sources/TokamakUIKit/Components/Protocols/UIViewComponent.swift
+++ b/Sources/TokamakUIKit/Components/Protocols/UIViewComponent.swift
@@ -23,8 +23,8 @@ protocol UIViewComponent: UIHostComponent, RefComponent {
   ) -> ViewBox<Target>
 }
 
-private func applyStyle<T: UIView, P: StyleProps>(_ target: ViewBox<T>,
-                                                  _ props: P) {
+private func applyStyle<T: UIView>(_ target: ViewBox<T>,
+                                   _ props: StyleProps) {
   guard let style = props.style else {
     return
   }


### PR DESCRIPTION
Currently none of the props that modify `CALayer` properties work in `TokamakAppKit`. The reason is that these properties [can only be update in `updateLayer` function of `NSView` subclass](https://developer.apple.com/documentation/appkit/nsview/1483580-updatelayer). This PR attempts to fix that.